### PR TITLE
Logo alinhado

### DIFF
--- a/Site/style.css
+++ b/Site/style.css
@@ -1,11 +1,12 @@
 .painelPrincipal{
-
     height: inherit;
     background-color: rgb(30, 40, 184);
     text-align: center;
     border: 4px solid black;
     margin: 0px;
     align-self: flex-start;
+    position: relative;
+    padding: 8px;
 }
 .subPainelPrincipal{
 
@@ -20,11 +21,11 @@
     border-radius: 500px;
     height: 20%;
     width: 20%;
-    
+
 }
 .textoTituloSite{
 
-    
+
     font-size: 72px;
     font-family: Impact, Haettenschweiler, 'Arial Narrow Bold', sans-serif;
     color: white;
@@ -76,8 +77,10 @@
     font-size: 25px;
     font-family: Impact, Haettenschweiler, 'Arial Narrow Bold', sans-serif;
     padding: 7px;
-    margin-top: 15px;
-    margin-right: 50px;
+
+    position: absolute;
+    top: 16px;
+    right: 16px;
 }
 #overlay {
     position: fixed; /* Sit on top of the page content */


### PR DESCRIPTION
Coloquei o botão de login com posição absoluta para não competir espaço com o logo, permitindo que o logo do CACiC se alinhe no centro mais corretamente.